### PR TITLE
#46: make graphql server deal better with empty filters 

### DIFF
--- a/experiments/duke/graphql_endpoint/graphql/queries.go
+++ b/experiments/duke/graphql_endpoint/graphql/queries.go
@@ -24,7 +24,8 @@ var GetPerson = &graphql.Field{
 }
 
 var PersonFilter *graphql.InputObject = graphql.NewInputObject(graphql.InputObjectConfig{
-	Name: "PersonFilter",
+	Name:        "PersonFilter",
+	Description: "Filter on People List",
 	Fields: graphql.InputObjectConfigFieldMap{
 		"limit": &graphql.InputObjectFieldConfig{
 			Type:         graphql.Int,
@@ -36,7 +37,7 @@ var PersonFilter *graphql.InputObject = graphql.NewInputObject(graphql.InputObje
 		},
 		"query": &graphql.InputObjectFieldConfig{
 			Type:         graphql.String,
-			DefaultValue: "*:*",
+			DefaultValue: "",
 		},
 	},
 })
@@ -52,7 +53,8 @@ var GetPeople = &graphql.Field{
 
 // TODO: very likely a way to avoid the code duplication
 var PublicationFilter *graphql.InputObject = graphql.NewInputObject(graphql.InputObjectConfig{
-	Name: "PublicationFilter",
+	Name:        "PublicationFilter",
+	Description: "Filter on Publication List",
 	Fields: graphql.InputObjectConfigFieldMap{
 		"limit": &graphql.InputObjectFieldConfig{
 			Type:         graphql.Int,
@@ -64,7 +66,7 @@ var PublicationFilter *graphql.InputObject = graphql.NewInputObject(graphql.Inpu
 		},
 		"query": &graphql.InputObjectFieldConfig{
 			Type:         graphql.String,
-			DefaultValue: "*:*",
+			DefaultValue: "",
 		},
 	},
 })
@@ -79,7 +81,8 @@ var GetPublications = &graphql.Field{
 }
 
 var GrantFilter *graphql.InputObject = graphql.NewInputObject(graphql.InputObjectConfig{
-	Name: "GrantFilter",
+	Name:        "GrantFilter",
+	Description: "Filter on Grant List",
 	Fields: graphql.InputObjectConfigFieldMap{
 		"limit": &graphql.InputObjectFieldConfig{
 			Type:         graphql.Int,
@@ -91,7 +94,7 @@ var GrantFilter *graphql.InputObject = graphql.NewInputObject(graphql.InputObjec
 		},
 		"query": &graphql.InputObjectFieldConfig{
 			Type:         graphql.String,
-			DefaultValue: "*:*",
+			DefaultValue: "",
 		},
 	},
 })

--- a/experiments/duke/graphql_endpoint/graphql/resolvers.go
+++ b/experiments/duke/graphql_endpoint/graphql/resolvers.go
@@ -44,21 +44,27 @@ type GrantFilterParam struct {
 }
 
 func convertPeopleFilter(params graphql.ResolveParams) (PersonFilterParam, error) {
-	result := PersonFilterParam{}
+	result := PersonFilterParam{
+		Filter: CommonFilter{Limit: 100, Offset: 0, Query: ""},
+	}
 	err := ms.Decode(params.Args, &result)
 	return result, err
 }
 
 func convertPublicationFilter(params graphql.ResolveParams) (PublicationFilterParam, error) {
 	// default values?
-	result := PublicationFilterParam{}
+	result := PublicationFilterParam{
+		Filter: CommonFilter{Limit: 100, Offset: 0, Query: ""},
+	}
 	err := ms.Decode(params.Args, &result)
 	return result, err
 }
 
 func convertGrantFilter(params graphql.ResolveParams) (GrantFilterParam, error) {
 	// default values?
-	result := GrantFilterParam{}
+	result := GrantFilterParam{
+		Filter: CommonFilter{Limit: 100, Offset: 0, Query: ""},
+	}
 	err := ms.Decode(params.Args, &result)
 	return result, err
 }
@@ -68,7 +74,7 @@ func peopleResolver(params graphql.ResolveParams) (interface{}, error) {
 	// e.g. if filter is not sent at all
 	limit := 100
 	offset := 0
-	query := "*:*"
+	query := ""
 	filter, err := convertPeopleFilter(params)
 
 	if err == nil {
@@ -78,6 +84,7 @@ func peopleResolver(params graphql.ResolveParams) (interface{}, error) {
 		query = fmt.Sprintf("*:%v*", filter.Filter.Query)
 	}
 
+	fmt.Printf("limit=%v,offset=%v,query=%v\n", limit, offset, query)
 	personList, err := elastic.FindPeople(limit, offset, query)
 	return personList, err
 }
@@ -86,7 +93,7 @@ func publicationResolver(params graphql.ResolveParams) (interface{}, error) {
 	// TODO: not finding a good way to default these
 	limit := 100
 	offset := 0
-	query := "*:*"
+	query := ""
 	filter, err := convertPublicationFilter(params)
 	if err == nil {
 		limit = filter.Filter.Limit
@@ -113,7 +120,7 @@ func personPublicationResolver(params graphql.ResolveParams) (interface{}, error
 func grantResolver(params graphql.ResolveParams) (interface{}, error) {
 	limit := 100
 	offset := 0
-	query := "*:*"
+	query := ""
 	filter, err := convertGrantFilter(params)
 	if err == nil {
 		limit = filter.Filter.Limit


### PR DESCRIPTION
after deploying I noticed if I left the filter blank it made an error - also it was making a query string of "*:**:*" (if blank) and elastic didn't like that query.  This looked to be working better